### PR TITLE
Upgrade to Hyper 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "README.md"
@@ -13,7 +13,7 @@ webpki-roots = "0.6.0"
 rustls = "0.5.3"
 
 [dependencies.hyper]
-version = "0.9.10"
+version = "0.10"
 default-features = false
 
 [dev-dependencies]


### PR DESCRIPTION
This appears to be required for me to be able to use Hyper 0.10.0.
There is so much here that I do not understand.
I do not know if making this change is appropriate in your library.