### PR TITLE
Fix endless loop in read when there is io error in underlying_write.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,10 @@ impl TlsStream {
     };
   }
 
+  fn check_io_error(&mut self) -> io::Result<()> {
+    self.io_error.take().map(Err).unwrap_or(Ok(()))
+  }
+
   fn close(&mut self, how: Shutdown) -> io::Result<()> {
     self.underlying.close(how)
   }
@@ -94,6 +98,7 @@ impl io::Read for TlsStream {
     // underlying_read does this.
     loop {
       try!(self.promote_tls_error());
+      try!(self.check_io_error());
 
       if self.eof {
         return Ok(0);


### PR DESCRIPTION
When this happens we early exit from `underlying_read` so flag for eof
is never set. Because of this all `underlying_*` methods now returns
early. Reading again from session data returns 0 which means exit
conditions from loop are never met.