### PR TITLE
Update *ring* dependency via Rustls (and webpki-roots) dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ homepage = "https://github.com/ctz/hyper-rustls"
 repository = "https://github.com/ctz/hyper-rustls"
 
 [dependencies]
-webpki-roots = "0.9.0"
-rustls = "0.6"
+webpki-roots = "0.10.0"
+rustls = "0.7"
 
 [dependencies.hyper]
 version = "0.10"


### PR DESCRIPTION
Before *ring* 0.9.3, it was possible to link multiple versions of *ring* into a program, e.g. if one version depended on *ring* 0.6 and another depended on *ring* 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link *ring*'s C/asm code correctly in that kind of situation. *ring* 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of *ring* to be linked into the same program, to prevent any problems this may cause.

*ring* 0.9.4 was released with an update to make some crates easier to update to 0.9.x.