### PR TITLE
connector: build from custom rustls ClientConfig

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -3,41 +3,60 @@
 extern crate futures;
 extern crate hyper;
 extern crate hyper_rustls;
+extern crate rustls;
 extern crate tokio_core;
 
-use futures::future::Future;
-use futures::Stream;
-use hyper::Uri;
-use std::env;
+use futures::{Future, Stream};
+use hyper::{client, Uri};
+use std::{env, io, fs};
 use std::io::Write;
 use std::str::FromStr;
 
 fn main() {
+    // First parameter is target URL (mandatory)
     let url = match env::args().nth(1) {
         Some(ref url) => Uri::from_str(url).expect("well-formed URI"),
         None => {
-            println!("Usage: client <url>");
+            println!("Usage: client <url> <ca_store>");
             return;
         }
     };
 
+    // Second parameter is custom Root-CA store (optional, defaults to webpki)
+    let mut ca = match env::args().nth(2) {
+        Some(ref path) => {
+            let f = fs::File::open(path).unwrap();
+            let rd = io::BufReader::new(f);
+            Some(rd)
+        }
+        None => None,
+    };
+
     let mut core = tokio_core::reactor::Core::new().unwrap();
     let handle = core.handle();
-    let client = hyper::Client::configure()
-                .connector(hyper_rustls::HttpsConnector::new(4, &handle))
-                .build(&handle);
-
+    let https = match ca {
+        Some(ref mut rd) => {
+            let mut http = client::HttpConnector::new(4, &handle);
+            http.enforce_http(false);
+            let mut tls = rustls::ClientConfig::new();
+            tls.root_store.add_pem_file(rd).unwrap();
+            hyper_rustls::HttpsConnector::from((http, tls))
+        }
+        None => hyper_rustls::HttpsConnector::new(4, &handle),
+    };
+    let client = client::Client::configure().connector(https).build(&handle);
 
     let work = client.get(url).and_then(|res| {
         println!("Status: {}", res.status());
         println!("Headers:\n{}", res.headers());
         res.body().for_each(|chunk| {
-            ::std::io::stdout().write_all(&chunk)
-                .map(|_| ())
-                .map_err(From::from)
+            ::std::io::stdout().write_all(&chunk).map(|_| ()).map_err(
+                From::from,
+            )
         })
     });
-    if let Err(err) =  core.run(work) {
+    if let Err(err) = core.run(work) {
         println!("FAILED: {}", err);
+        std::process::exit(1)
     }
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -59,7 +59,11 @@ fn load_private_key(filename: &str) -> rustls::PrivateKey {
 }
 
 fn main() {
-    let addr = "127.0.0.1:1337".parse().unwrap();
+    let port = match std::env::args().nth(1) {
+        Some(ref p) => p.to_owned(),
+        None => "1337".to_owned(),
+    };
+    let addr = format!("127.0.0.1:{}", port).parse().unwrap();
     let certs = load_certs("examples/sample.pem");
     let key = load_private_key("examples/sample.rsa");
     let mut cfg = rustls::ServerConfig::new();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@ fn client() {
 #[test]
 fn server() {
   let mut srv = Command::new("target/debug/examples/server")
+    .arg("1337")
     .spawn()
     .expect("cannot run server example");
 
@@ -42,4 +43,27 @@ fn server() {
 
   srv.kill()
     .unwrap();
+}
+
+#[test]
+fn custom_ca_store() {
+    let mut srv = Command::new("target/debug/examples/server")
+        .arg("1338")
+        .spawn()
+        .expect("cannot run server example");
+
+    thread::sleep(time::Duration::from_secs(1));
+
+    let rc = Command::new("target/debug/examples/client")
+        .arg("https://localhost:1338")
+        .arg("examples/sample.pem")
+        .output()
+        .expect("cannot run client example");
+
+    srv.kill()
+        .unwrap();
+
+    if !rc.status.success() {
+        assert_eq!(String::from_utf8_lossy(&rc.stdout), "");
+    }
 }


### PR DESCRIPTION
This PR introduces support for building an HttpsConnector from an existing rustls ClientConfig.
It implements a `From` trait following hyper-tls approach: https://docs.rs/hyper-tls/0.1.1/hyper_tls/struct.HttpsConnector.html (even if I'm not super-happy with a tuple).
It re-uses existing certs, client and server example to build a full roundtrip test.

Fixes: https://github.com/ctz/hyper-rustls/issues/27
Supersedes: https://github.com/ctz/hyper-rustls/pull/6