### PR TITLE
Made tlsclient cloneable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,7 @@ impl NetworkStream for WrappedStream {
   }
 }
 
+#[derive(Clone)]
 pub struct TlsClient {
   pub cfg: Arc<rustls::ClientConfig>
 }


### PR DESCRIPTION
I am checking Hyper-Rustls on Servo. I have worked on replacing Rust-OpenSSL with Hyper-Rustls.
This requires TLSClient to be cloneable. This PR does that.