### PR TITLE
examples/server: fix warnings

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -3,7 +3,6 @@
 extern crate futures;
 extern crate hyper;
 extern crate rustls;
-extern crate tokio_core;
 extern crate tokio_proto;
 extern crate tokio_rustls;
 


### PR DESCRIPTION
This fixes an "unused external crate" failure on beta and nightly.