### PR TITLE
 Update to rustls 0.12 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,12 @@ repository = "https://github.com/ctz/hyper-rustls"
 [dependencies]
 futures = "0.1.13"
 hyper = "0.11"
-rustls = "0.11.0"
+rustls = "0.12"
 tokio-core = "0.1.7"
 tokio-io = "0.1.1"
 tokio-proto = "0.1"
-tokio-rustls = { version = "0.4.0", features = [ "tokio-proto" ] }
+tokio-rustls = { version = "0.5", features = [ "tokio-proto" ] }
 tokio-service = "0.1.0"
-webpki-roots = "0.13.0"
-ct-logs = "0.2.0"
+webpki = "0.18.0-alpha"
+webpki-roots = "0.14"
+ct-logs = "0.3"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -65,7 +65,7 @@ fn main() {
     let addr = format!("127.0.0.1:{}", port).parse().unwrap();
     let certs = load_certs("examples/sample.pem");
     let key = load_private_key("examples/sample.rsa");
-    let mut cfg = rustls::ServerConfig::new();
+    let mut cfg = rustls::ServerConfig::new(rustls::NoClientAuth::new());
     cfg.set_single_cert(certs, key);
     let tls = proto::Server::new(Http::new(), std::sync::Arc::new(cfg));
     let tcp = tokio_proto::TcpServer::new(tls, addr);

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -27,9 +27,14 @@ impl HttpsConnector {
         let mut http = HttpConnector::new(threads, handle);
         http.enforce_http(false);
         let mut config = ClientConfig::new();
-        config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+        config
+            .root_store
+            .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
         config.ct_logs = Some(&ct_logs::LOGS);
-        HttpsConnector { http: http, tls_config: Arc::new(config) }
+        HttpsConnector {
+            http: http,
+            tls_config: Arc::new(config),
+        }
     }
 }
 
@@ -59,44 +64,38 @@ impl Service for HttpsConnector {
         let host: DNSName = match uri.host() {
             Some(host) => match DNSNameRef::try_from_ascii_str(host) {
                 Ok(host) => host.into(),
-                Err(err) => return HttpsConnecting(
-                    Box::new(
-                        ::futures::future::err(
-                            io::Error::new(
-                                io::ErrorKind::InvalidInput,
-                                format!("invalid url: {:?}", err),
-                            )
-                        )
-                    )
-                ),
+                Err(err) => {
+                    return HttpsConnecting(Box::new(::futures::future::err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("invalid url: {:?}", err),
+                    ))))
+                }
             },
-            None => return HttpsConnecting(
-                Box::new(
-                    ::futures::future::err(
-                        io::Error::new(
-                            io::ErrorKind::InvalidInput,
-                            "invalid url, missing host"
-                            )
-                        )
-                    )
-                ),
+            None => {
+                return HttpsConnecting(Box::new(::futures::future::err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "invalid url, missing host",
+                ))))
+            }
         };
         let connecting = self.http.call(uri);
 
         HttpsConnecting(if is_https {
             let tls = self.tls_config.clone();
-            Box::new(connecting.and_then(move |tcp| {
-                    tls
-                    .connect_async(host.as_ref(), tcp)
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
-            }).map(|tls| MaybeHttpsStream::Https(tls))
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e)))
+            Box::new(
+                connecting
+                    .and_then(move |tcp| {
+                        tls.connect_async(host.as_ref(), tcp)
+                            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+                    })
+                    .map(|tls| MaybeHttpsStream::Https(tls))
+                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e)),
+            )
         } else {
             Box::new(connecting.map(|tcp| MaybeHttpsStream::Http(tcp)))
         })
     }
 }
-
 
 pub struct HttpsConnecting(Box<Future<Item = MaybeHttpsStream, Error = io::Error>>);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ extern crate tokio_core;
 extern crate tokio_io;
 extern crate tokio_rustls;
 extern crate tokio_service;
+extern crate webpki;
 extern crate webpki_roots;
 extern crate ct_logs;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! }
 //! ```
 
+extern crate ct_logs;
 extern crate futures;
 extern crate hyper;
 extern crate rustls;
@@ -34,7 +35,6 @@ extern crate tokio_rustls;
 extern crate tokio_service;
 extern crate webpki;
 extern crate webpki_roots;
-extern crate ct_logs;
 
 mod connector;
 mod stream;


### PR DESCRIPTION
This is needed in order to fix some recent breakage in ring on nightly
builds.

Fixes #37.