### PR TITLE
travis: add a clippy pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,23 @@ rust:
   - stable
   - beta
   - nightly
+  - nightly-2018-06-11
+
 matrix:
   allow_failures:
     - rust: nightly
+
+env:
+  global:
+    - CLIPPY_VERSION=0.0.207
+    - CLIPPY_RUST_VERSION=nightly-2018-06-11
+before_script:
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
+      cargo install clippy --vers $CLIPPY_VERSION --force;
+    fi'
+
 script:
   - cargo test
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
+      cargo clippy -- -D warnings;
+    fi'


### PR DESCRIPTION
As clippy is not shipped via rustup and doesn't yet work on stable, this pins to the latest released version and to a known-working recent nightly.

Getting new lints in the future will require manual version bumping, but at least this catches regressions.