### PR TITLE
Forward read_buf and write_buf for MaybeHttpsStream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/ctz/hyper-rustls"
 repository = "https://github.com/ctz/hyper-rustls"
 
 [dependencies]
+bytes = "0.4"
 ct-logs = "0.4"
 futures = "0.1.21"
 http = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //! }
 //! ```
 
+extern crate bytes;
 extern crate ct_logs;
 extern crate futures;
 extern crate http;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,5 +1,6 @@
 // Copied from hyperium/hyper-tls#62e3376/src/stream.rs
 
+use bytes::{Buf, BufMut};
 use futures::Poll;
 use rustls::ClientSession;
 use std::fmt;
@@ -59,6 +60,13 @@ impl<T: AsyncRead + AsyncWrite> AsyncRead for MaybeHttpsStream<T> {
             MaybeHttpsStream::Https(ref s) => s.prepare_uninitialized_buffer(buf),
         }
     }
+
+    fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+        match *self {
+            MaybeHttpsStream::Http(ref mut s) => s.read_buf(buf),
+            MaybeHttpsStream::Https(ref mut s) => s.read_buf(buf),
+        }
+    }
 }
 
 impl<T: AsyncRead + AsyncWrite> AsyncWrite for MaybeHttpsStream<T> {
@@ -66,6 +74,13 @@ impl<T: AsyncRead + AsyncWrite> AsyncWrite for MaybeHttpsStream<T> {
         match *self {
             MaybeHttpsStream::Http(ref mut s) => s.shutdown(),
             MaybeHttpsStream::Https(ref mut s) => s.shutdown(),
+        }
+    }
+
+    fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+        match *self {
+            MaybeHttpsStream::Http(ref mut s) => s.write_buf(buf),
+            MaybeHttpsStream::Https(ref mut s) => s.write_buf(buf),
         }
     }
 }


### PR DESCRIPTION
This is more beneficial when it is `Http`, as it allows hyper to make use vectored IO for better throughput.