### PR TITLE
Optionally disable pulling in the tokio runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ before_script:
 
 script:
   - cargo test
+  - cargo test --all-features
+  - cargo test --no-default-features
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
       cargo clippy -- -D warnings;
     fi'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,29 @@ repository = "https://github.com/ctz/hyper-rustls"
 
 [dependencies]
 bytes = "0.4"
-ct-logs = "0.5"
+ct-logs = { version = "0.5", optional = true }
 futures = "0.1.21"
-hyper = "0.12.14"
+hyper = { version = "0.12.14", default-features = false }
 rustls = "0.15"
 tokio-io = "0.1.1"
 tokio-rustls = "0.9"
 webpki = "0.19.0"
-webpki-roots = "0.16"
+webpki-roots = { version = "0.16", optional = true }
 
 [dev-dependencies]
 tokio = "0.1"
 tokio-tcp = "0.1"
+
+[features]
+default = ["tokio-runtime"]
+tokio-runtime = ["hyper/runtime", "ct-logs", "webpki-roots"]
+
+[[example]]
+name = "client"
+path = "examples/client.rs"
+required-features = ["tokio-runtime"]
+
+[[example]]
+name = "server"
+path = "examples/server.rs"
+required-features = ["tokio-runtime"]

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -1,13 +1,12 @@
-use ct_logs;
 use futures::{Future, Poll};
 use hyper::client::connect::{self, Connect};
+#[cfg(feature = "tokio-runtime")]
 use hyper::client::HttpConnector;
 use rustls::{ClientConfig, Session};
 use std::sync::Arc;
 use std::{fmt, io};
 use tokio_rustls::TlsConnector;
 use webpki::{DNSName, DNSNameRef};
-use webpki_roots;
 
 use stream::MaybeHttpsStream;
 
@@ -18,11 +17,15 @@ pub struct HttpsConnector<T> {
     tls_config: Arc<ClientConfig>,
 }
 
+#[cfg(feature = "tokio-runtime")]
 impl HttpsConnector<HttpConnector> {
     /// Construct a new `HttpsConnector`.
     ///
     /// Takes number of DNS worker threads.
     pub fn new(threads: usize) -> Self {
+        use ct_logs;
+        use webpki_roots;
+
         let mut http = HttpConnector::new(threads);
         http.enforce_http(false);
         let mut config = ClientConfig::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,25 +5,28 @@
 //! ## Example
 //!
 //! ```no_run
-//! extern crate hyper;
-//! extern crate hyper_rustls;
-//! extern crate tokio;
-//!
+//! # #[cfg(feature = "tokio-runtime")]
+//! # extern crate hyper;
+//! #
+//! # #[cfg(feature = "tokio-runtime")]
+//! # fn main() {
 //! use hyper::{Body, Client, StatusCode, Uri};
 //!
-//! fn main() {
-//!     let mut rt = tokio::runtime::Runtime::new().unwrap();
-//!     let url = ("https://hyper.rs").parse().unwrap();
-//!     let https = hyper_rustls::HttpsConnector::new(4);
+//! let mut rt = tokio::runtime::Runtime::new().unwrap();
+//! let url = ("https://hyper.rs").parse().unwrap();
+//! let https = hyper_rustls::HttpsConnector::new(4);
 //!
-//!     let client: Client<_, hyper::Body> = Client::builder().build(https);
+//! let client: Client<_, hyper::Body> = Client::builder().build(https);
 //!
-//!     let res = rt.block_on(client.get(url)).unwrap();
-//!     assert_eq!(res.status(), StatusCode::OK);
-//! }
+//! let res = rt.block_on(client.get(url)).unwrap();
+//! assert_eq!(res.status(), StatusCode::OK);
+//! # }
+//! # #[cfg(not(feature = "tokio-runtime"))]
+//! # fn main() {}
 //! ```
 
 extern crate bytes;
+#[cfg(feature = "tokio-runtime")]
 extern crate ct_logs;
 extern crate futures;
 extern crate hyper;
@@ -31,6 +34,7 @@ extern crate rustls;
 extern crate tokio_io;
 extern crate tokio_rustls;
 extern crate webpki;
+#[cfg(feature = "tokio-runtime")]
 extern crate webpki_roots;
 
 mod connector;


### PR DESCRIPTION
Before this patch, hyper-rustls required pulling in the tokio runtime due to it's use of `hyper::client::HttpConnector`. Unfortunately Fuchsia does not support tokio, which prevents our use of this
library. This PR allows us to optionally disable pulling in tokio, and instead swap in our own version of the hyper `HttpConnector`.

If this PR is accepted, would it be possible for a new version to be cut that allows us to opt out of the tokio dependency? Thanks so much!