### PR TITLE
Update to *ring* 0.16

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
   clippy_toolchain: 1.33.0
-  minimum_toolchain: 1.31.0
+  minimum_toolchain: 1.36.0
 
 resources:
   repositories:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  clippy_toolchain: 1.33.0
+  clippy_toolchain: 1.36.0
   minimum_toolchain: 1.36.0
 
 resources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.32.0  # pinned toolchain for clippy
+  - 1.36.0  # pinned toolchain for clippy
   - stable
   - beta
   - nightly
@@ -11,7 +11,7 @@ matrix:
 
 env:
   global:
-    - CLIPPY_RUST_VERSION=1.32.0
+    - CLIPPY_RUST_VERSION=1.36.0
 
 before_script:
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ repository = "https://github.com/ctz/hyper-rustls"
 
 [dependencies]
 bytes = "0.4"
-ct-logs = { version = "0.5", optional = true }
-futures = "0.1.21"
+ct-logs = { version = "^0.6.0", optional = true }
+futures = "^0.1.28"
 hyper = { version = "0.12.14", default-features = false }
-rustls = "0.15"
+rustls = "0.16"
 tokio-io = "0.1.1"
-tokio-rustls = "0.9"
-webpki = "0.19.0"
-webpki-roots = { version = "0.16", optional = true }
+tokio-rustls = "^0.10.0"
+webpki = "^0.21.0"
+webpki-roots = { version = "^0.17.0", optional = true }
 
 [dev-dependencies]
 tokio = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.16.1"
+version = "0.17.0"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "README.md"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -84,7 +84,7 @@ fn run_server() -> io::Result<()> {
 }
 
 // Future result: either a hyper body or an error.
-type ResponseFuture = Box<Future<Item = Response<Body>, Error = hyper::Error> + Send>;
+type ResponseFuture = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
 // Custom echo service, handling two different routes and a
 // catch-all 404 responder.

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -60,7 +60,8 @@ fn run_server() -> io::Result<()> {
     let tcp = tokio_tcp::TcpListener::bind(&addr)?;
     let tls_acceptor = TlsAcceptor::from(tls_cfg);
     // Prepare a long-running future stream to accept and serve cients.
-    let tls = tcp.incoming()
+    let tls = tcp
+        .incoming()
         .and_then(move |s| tls_acceptor.accept(s))
         .then(|r| match r {
             Ok(x) => Ok::<_, io::Error>(Some(x)),
@@ -78,8 +79,7 @@ fn run_server() -> io::Result<()> {
     // Run the future, keep going until an error occurs.
     println!("Starting to serve on https://{}.", addr);
     let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on_all(fut)
-        .map_err(|e| error(format!("{}", e)))?;
+    rt.block_on_all(fut).map_err(|e| error(format!("{}", e)))?;
     Ok(())
 }
 
@@ -110,22 +110,19 @@ fn echo(req: Request<Body>) -> ResponseFuture {
 // Load public certificate from file.
 fn load_certs(filename: &str) -> io::Result<Vec<rustls::Certificate>> {
     // Open certificate file.
-    let certfile = fs::File::open(filename).map_err(|e| {
-        error(format!("failed to open {}: {}", filename, e))
-    })?;
+    let certfile = fs::File::open(filename)
+        .map_err(|e| error(format!("failed to open {}: {}", filename, e)))?;
     let mut reader = io::BufReader::new(certfile);
 
     // Load and return certificate.
-    pemfile::certs(&mut reader)
-        .map_err(|_| error("failed to load certificate".into()))
+    pemfile::certs(&mut reader).map_err(|_| error("failed to load certificate".into()))
 }
 
 // Load private key from file.
 fn load_private_key(filename: &str) -> io::Result<rustls::PrivateKey> {
     // Open keyfile.
-    let keyfile = fs::File::open(filename).map_err(|e| {
-        error(format!("failed to open {}: {}", filename, e))
-    })?;
+    let keyfile = fs::File::open(filename)
+        .map_err(|e| error(format!("failed to open {}: {}", filename, e)))?;
     let mut reader = io::BufReader::new(keyfile);
 
     // Load and return a single private key.

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -94,7 +94,8 @@ where
                     },
                 )
                 .and_then(move |(tcp, conn, dnsname)| {
-                    connector.connect(dnsname.as_ref(), tcp)
+                    connector
+                        .connect(dnsname.as_ref(), tcp)
                         .and_then(|tls| {
                             let connected = if tls.get_ref().1.get_alpn_protocol() == Some(b"h2") {
                                 conn.negotiated_h2()

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -23,9 +23,6 @@ impl HttpsConnector<HttpConnector> {
     ///
     /// Takes number of DNS worker threads.
     pub fn new(threads: usize) -> Self {
-        use ct_logs;
-        use webpki_roots;
-
         let mut http = HttpConnector::new(threads);
         http.enforce_http(false);
         let mut config = ClientConfig::new();

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -2,18 +2,17 @@
 
 use bytes::{Buf, BufMut};
 use futures::Poll;
-use rustls::ClientSession;
 use std::fmt;
 use std::io::{self, Read, Write};
 use tokio_io::{AsyncRead, AsyncWrite};
-use tokio_rustls::TlsStream;
+use tokio_rustls::client::TlsStream;
 
 /// A stream that might be protected with TLS.
 pub enum MaybeHttpsStream<T> {
     /// A stream over plain text.
     Http(T),
     /// A stream protected with TLS.
-    Https(TlsStream<T, ClientSession>),
+    Https(TlsStream<T>),
 }
 
 impl<T: fmt::Debug> fmt::Debug for MaybeHttpsStream<T> {
@@ -30,7 +29,10 @@ impl<T: Read + Write> Read for MaybeHttpsStream<T> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match *self {
             MaybeHttpsStream::Http(ref mut s) => s.read(buf),
-            MaybeHttpsStream::Https(ref mut s) => s.read(buf),
+            MaybeHttpsStream::Https(ref mut s) => {
+                let (_, cs) = s.get_mut();
+                cs.read(buf)
+            }
         }
     }
 }
@@ -40,7 +42,10 @@ impl<T: Read + Write> Write for MaybeHttpsStream<T> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match *self {
             MaybeHttpsStream::Http(ref mut s) => s.write(buf),
-            MaybeHttpsStream::Https(ref mut s) => s.write(buf),
+            MaybeHttpsStream::Https(ref mut s) => {
+                let (_, cs) = s.get_mut();
+                cs.write(buf)
+            }
         }
     }
 
@@ -48,7 +53,10 @@ impl<T: Read + Write> Write for MaybeHttpsStream<T> {
     fn flush(&mut self) -> io::Result<()> {
         match *self {
             MaybeHttpsStream::Http(ref mut s) => s.flush(),
-            MaybeHttpsStream::Https(ref mut s) => s.flush(),
+            MaybeHttpsStream::Https(ref mut s) => {
+                let (_, cs) = s.get_mut();
+                cs.flush()
+            }
         }
     }
 }


### PR DESCRIPTION
This updates *ring* to 0.16 (plus all related dependencies).
It also contains separate commits for a global rustfmt pass, CI compatibility fixes, and a version bump to prepare for the next release.

Closes: https://github.com/ctz/hyper-rustls/issues/74