### PR TITLE
cargo: switch to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hyper-rustls"
 version = "0.17.0"
+edition = "2018"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "README.md"

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -8,7 +8,7 @@ use std::{fmt, io};
 use tokio_rustls::TlsConnector;
 use webpki::{DNSName, DNSNameRef};
 
-use stream::MaybeHttpsStream;
+use crate::stream::MaybeHttpsStream;
 
 /// A Connector for the `https` scheme.
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,5 +40,5 @@ extern crate webpki_roots;
 mod connector;
 mod stream;
 
-pub use connector::HttpsConnector;
-pub use stream::MaybeHttpsStream;
+pub use crate::connector::HttpsConnector;
+pub use crate::stream::MaybeHttpsStream;


### PR DESCRIPTION
This fixes the codebase for Rust edition 2018, and switches the crate to it.