### PR TITLE
Update Dependencies to support Rust Stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,16 @@ repository = "https://github.com/ctz/hyper-rustls"
 [dependencies]
 bytes = "0.4"
 ct-logs = { version = "^0.6.0", optional = true }
-futures-preview = { version = "0.3.0-alpha.18", features = ["async-await", "nightly"] }
-hyper = { version = "0.13.0-alpha.1", default-features = false }
+futures-util-preview = { version = "0.3.0-alpha.19" }
+hyper = { version = "0.13.0-alpha.4", default-features = false, features = ["unstable-stream"] }
 rustls = "0.16"
-tokio-io = { version="0.2.0-alpha.2" }
-tokio-rustls = "0.12.0-alpha.1"
+tokio-io = { version="0.2.0-alpha.6" }
+tokio-rustls = "0.12.0-alpha.4"
 webpki = "^0.21.0"
 webpki-roots = { version = "^0.17.0", optional = true }
 
 [dev-dependencies]
-tokio = "0.2.0-alpha.2"
+tokio = "0.2.0-alpha.6"
 
 [features]
 default = ["tokio-runtime"]

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -2,9 +2,8 @@
 //!
 //! First parameter is the mandatory URL to GET.
 //! Second parameter is an optional path to CA store.
-#![feature(async_await)]
-use futures::TryStreamExt;
-use hyper::{client, Uri, Body, Chunk};
+use futures_util::TryStreamExt;
+use hyper::{client, Body, Chunk, Uri};
 use std::str::FromStr;
 use std::{env, fs, io};
 
@@ -67,16 +66,18 @@ async fn run_client() -> io::Result<()> {
     // the returned headers, collects the whole body and prints it to
     // stdout.
     let fut = async move {
-        let res = client.get(url).await.map_err(|e| {
-            error(format!("Could not get: {:?}", e))
-        })?;
+        let res = client
+            .get(url)
+            .await
+            .map_err(|e| error(format!("Could not get: {:?}", e)))?;
         println!("Status:\n{}", res.status());
         println!("Headers:\n{:#?}", res.headers());
 
         let body: Body = res.into_body();
-        let body: Chunk = body.try_concat().await.map_err(|e| {
-            error(format!("Could not get body: {:?}", e))
-        })?;
+        let body: Chunk = body
+            .try_concat()
+            .await
+            .map_err(|e| error(format!("Could not get body: {:?}", e)))?;
         println!("Body:\n{}", String::from_utf8_lossy(&body));
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
 //! # #[cfg(not(feature = "tokio-runtime"))]
 //! # fn main() {}
 //! ```
-#![feature(async_await)]
 mod connector;
 mod stream;
 


### PR DESCRIPTION
Since async await is now stable on Rust Beta 1.39, using the futures ecosystem should work just fine, except there's still many crates that have #![feature(async_await)] somewhere in their dependency graph. Most crates have been updated by now. This updates hyper-rustls as well.