### PR TITLE
Use ALPN by default to negotiate for HTTP2

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -28,6 +28,7 @@ impl HttpsConnector<HttpConnector> {
         let mut http = HttpConnector::new();
         http.enforce_http(false);
         let mut config = ClientConfig::new();
+        config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
         config.root_store = rustls_native_certs::load_native_certs()
             .expect("cannot access native cert store");
         config.ct_logs = Some(&ct_logs::LOGS);


### PR DESCRIPTION
Hyper supports HTTP2, so hyper-rustls should use ALPN to negotiate for HTTP2 by default.

Resolves #94 