### PR TITLE
don't depend on hyper/tcp feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/ctz/hyper-rustls"
 bytes = "0.5.2"
 ct-logs = { version = "^0.6.0", optional = true }
 futures-util = "0.3.1"
-hyper = { version = "0.13.0", default-features = false, features = ["tcp"] }
+hyper = { version = "0.13.0", default-features = false }
 rustls = "0.16"
 tokio = "0.2.4"
 tokio-rustls = "0.12.1"


### PR DESCRIPTION
On fuchsia, we don't support the mio and tokio runtime yet, and so in order to use hyper-rustls, we need to compile it with `default-features = false`. Unfortunately, in https://github.com/ctz/hyper-rustls/pull/96, @CryZe added a hard requirement for the hyper "tcp" feature, which pulls in the tokio runtime.

To restore our ability to use hyper-rustls, this patch migrates the "hyper/tcp" hard feature requirement to an optional "tcp" feature. Note that we don't need to change the default case, because the "hyper/runtime" feature already depends on "hyper/tcp".