### PR TITLE
Update to allow use of webpki-roots where rustls-native-certs fails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ before_script:
 
 script:
   - cargo test
-  - cargo test --all-features
+  - cargo test --no-default-features --features native-tokio
+  - cargo test --no-default-features --features webpki-tokio
   - cargo test --no-default-features
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
       cargo clippy -- -D warnings;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ tokio-runtime =  ["hyper/runtime", "ct-logs"]
 [[example]]
 name = "client"
 path = "examples/client.rs"
+required-features = ["tokio-runtime"]
 
 [[example]]
 name = "server"
 path = "examples/server.rs"
+required-features = ["tokio-runtime"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.19.1"
+version = "0.20.0"
 edition = "2018"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"
@@ -10,29 +10,28 @@ homepage = "https://github.com/ctz/hyper-rustls"
 repository = "https://github.com/ctz/hyper-rustls"
 
 [dependencies]
-bytes = "0.5.2"
-ct-logs = { version = "^0.6.0", optional = true }
-futures-util = "0.3.1"
-hyper = { version = "0.13.0", default-features = false }
+bytes = "0.5"
+ct-logs = { version = "0.6", optional = true }
+futures-util = "0.3"
+hyper = { version = "0.13", default-features = false }
 rustls = "0.16"
-tokio = "0.2.4"
-tokio-rustls = "0.12.1"
-webpki = "^0.21.0"
-rustls-native-certs = { version = "^0.1.0", optional = true }
+rustls-native-certs = { version = "0.1", optional = true }
+tokio = "0.2"
+tokio-rustls = "0.12"
+webpki = "0.21"
+webpki-roots = { version = "0.18", optional = true }
 
 [dev-dependencies]
-tokio = { version = "0.2.4", features = ["io-std", "macros", "dns", "stream"] }
+tokio = { version = "0.2", features = ["io-std", "macros", "dns", "stream"] }
 
 [features]
-default = ["tokio-runtime"]
-tokio-runtime = ["hyper/runtime", "ct-logs", "rustls-native-certs"]
+default = ["tokio-runtime", "rustls-native-certs"]
+tokio-runtime =  ["hyper/runtime", "ct-logs"]
 
 [[example]]
 name = "client"
 path = "examples/client.rs"
-required-features = ["tokio-runtime"]
 
 [[example]]
 name = "server"
 path = "examples/server.rs"
-required-features = ["tokio-runtime"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.20.0"
+version = "0.19.2"
 edition = "2018"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "0.2", features = ["io-std", "macros", "dns", "stream"] }
 
 [features]
 default = ["tokio-runtime", "rustls-native-certs"]
+webpki-tokio = ["tokio-runtime", "webpki-roots"]
 tokio-runtime =  ["hyper/runtime", "ct-logs"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ webpki-roots = { version = "0.18", optional = true }
 tokio = { version = "0.2", features = ["io-std", "macros", "dns", "stream"] }
 
 [features]
-default = ["tokio-runtime", "rustls-native-certs"]
+default = ["native-tokio"]
 webpki-tokio = ["tokio-runtime", "webpki-roots"]
+native-tokio = ["tokio-runtime", "rustls-native-certs"]
 tokio-runtime =  ["hyper/runtime", "ct-logs"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-rustls"
-version = "0.19.2"
+version = "0.19.1"
 edition = "2018"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"

--- a/admin/pipelines/cargo-steps.yml
+++ b/admin/pipelines/cargo-steps.yml
@@ -5,8 +5,8 @@ steps:
   - script: cargo test
     displayName: "cargo test (debug; default features)"
     env: { "RUST_BACKTRACE": "1" }
-  - script: cargo test --all-features
-    displayName: "cargo test (debug; all features)"
+  - script: cargo test --no-default-features --features webpki-tokio
+    displayName: "cargo test (debug; webpi-roots feature)"
     env: { "RUST_BACKTRACE": "1" }
   - script: cargo test --no-default-features
     displayName: "cargo build (debug; no default features)"

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -33,8 +33,17 @@ impl HttpsConnector<HttpConnector> {
         http.enforce_http(false);
         let mut config = ClientConfig::new();
         config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-        config.root_store = rustls_native_certs::load_native_certs()
-            .expect("cannot access native cert store");
+        #[cfg(feature = "rustls-native-certs")] 
+        {
+            config.root_store = rustls_native_certs::load_native_certs()
+                .expect("cannot access native cert store");
+        }
+        #[cfg(feature = "webpki-roots")] 
+        {
+            config
+                .root_store
+                .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+        }
         config.ct_logs = Some(&ct_logs::LOGS);
         HttpsConnector {
             http,

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -23,7 +23,7 @@ pub struct HttpsConnector<T> {
     tls_config: Arc<ClientConfig>,
 }
 
-#[cfg(feature = "tokio-runtime")]
+#[cfg(all(any(feature = "rustls-native-certs", feature = "webpki-roots"), feature = "tokio-runtime"))]
 impl HttpsConnector<HttpConnector> {
     /// Construct a new `HttpsConnector`.
     ///
@@ -52,7 +52,7 @@ impl HttpsConnector<HttpConnector> {
     }
 }
 
-#[cfg(feature = "tokio-runtime")]
+#[cfg(all(any(feature = "rustls-native-certs", feature = "webpki-roots"), feature = "tokio-runtime"))]
 impl Default for HttpsConnector<HttpConnector> {
     fn default() -> Self {
         Self::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,15 @@
 //! # fn main() {}
 //! ```
 
+#[cfg(all(
+    feature = "tokio-runtime",
+    any(not(feature = "rustls-native-certs"), feature = "webpki-roots"),
+    any(not(feature = "webpki-roots"), feature = "rustls-native-certs")
+))]
+compile_error!(
+    "Must enable exactly one of rustls-native-certs (default) or webpki-roots with tokio-runtime! (note: use `default-features = false' in a binary crate for one or other)"
+);
+
 mod connector;
 mod stream;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,15 +22,6 @@
 //! # fn main() {}
 //! ```
 
-#[cfg(all(
-    feature = "tokio-runtime",
-    any(not(feature = "rustls-native-certs"), feature = "webpki-roots"),
-    any(not(feature = "webpki-roots"), feature = "rustls-native-certs")
-))]
-compile_error!(
-    "Must enable exactly one of rustls-native-certs (default) or webpki-roots with tokio-runtime! (note: use `default-features = false' in a binary crate for one or other)"
-);
-
 mod connector;
 mod stream;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! ## Example
 //!
 //! ```no_run
-//! # #[cfg(feature = "tokio-runtime")]
+//! # #[cfg(all(any(feature = "rustls-native-certs", feature = "webpki-roots"), feature = "tokio-runtime"))]
 //! # fn main() {
 //! use hyper::{Body, Client, StatusCode, Uri};
 //!
@@ -21,6 +21,15 @@
 //! # #[cfg(not(feature = "tokio-runtime"))]
 //! # fn main() {}
 //! ```
+
+#[cfg(all(
+    feature = "tokio-runtime",
+    any(not(feature = "rustls-native-certs"), feature = "webpki-roots"),
+    any(not(feature = "webpki-roots"), feature = "rustls-native-certs")
+))]
+compile_error!(
+    "Must enable exactly one of rustls-native-certs (default) or webpki-roots with tokio-runtime!"
+);
 
 mod connector;
 mod stream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
     any(not(feature = "webpki-roots"), feature = "rustls-native-certs")
 ))]
 compile_error!(
-    "Must enable exactly one of rustls-native-certs (default) or webpki-roots with tokio-runtime!"
+    "Must enable exactly one of rustls-native-certs (default) or webpki-roots with tokio-runtime! (note: use `default-features = false' in a binary crate for one or other)"
 );
 
 mod connector;


### PR DESCRIPTION
This adds the option to use webpki-roots in the cases where rustls-native-certs fails or is impossible, for example `aarch64-linux-android` (<https://github.com/ctz/rustls-native-certs/issues/3> is not possible, as the keystore is unavailable as per <https://developer.android.com/training/articles/keystore>), `aarch64-unknown-none` (it literally doesn't exist), microcontroller classes, `x86_64-unknown-cloudabi`/`aarch64-unknown-cloudabi` (also doesn't exist), `wasm32-wasi` (needs embedded or local thing), etc.

~~This additionally adds a compile time check for handling root store without required feature.~~