### PR TITLE
Simplify `From` calls

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -36,10 +36,7 @@ impl HttpsConnector<HttpConnector> {
         config.root_store = rustls_native_certs::load_native_certs()
             .expect("cannot access native cert store");
         config.ct_logs = Some(&ct_logs::LOGS);
-        HttpsConnector {
-            http,
-            tls_config: Arc::new(config),
-        }
+        (http, config).into()
     }
 }
 
@@ -56,20 +53,11 @@ impl<T> fmt::Debug for HttpsConnector<T> {
     }
 }
 
-impl<T> From<(T, ClientConfig)> for HttpsConnector<T> {
-    fn from(args: (T, ClientConfig)) -> Self {
+impl<H, C: Into<Arc<ClientConfig>>> From<(H, C)> for HttpsConnector<H> {
+    fn from((http, cfg): (H, C)) -> Self {
         HttpsConnector {
-            http: args.0,
-            tls_config: Arc::new(args.1),
-        }
-    }
-}
-
-impl<T> From<(T, Arc<ClientConfig>)> for HttpsConnector<T> {
-    fn from(args: (T, Arc<ClientConfig>)) -> Self {
-        HttpsConnector {
-            http: args.0,
-            tls_config: args.1,
+            http,
+            tls_config: cfg.into(),
         }
     }
 }

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -53,7 +53,10 @@ impl<T> fmt::Debug for HttpsConnector<T> {
     }
 }
 
-impl<H, C: Into<Arc<ClientConfig>>> From<(H, C)> for HttpsConnector<H> {
+impl<H, C> From<(H, C)> for HttpsConnector<H>
+where
+    C: Into<Arc<ClientConfig>> 
+{
     fn from((http, cfg): (H, C)) -> Self {
         HttpsConnector {
             http,


### PR DESCRIPTION
Thanks to `impl<T> From<T> for T` and `impl<T> From<T> for Arc<T>` in std.