### PR TITLE
Panic if no trust anchors are found

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -54,6 +54,9 @@ impl HttpsConnector<HttpConnector> {
                 .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
         }
         config.ct_logs = Some(&ct_logs::LOGS);
+        if config.root_store.is_empty() {
+            panic!("no CA certificates found");
+        }
         (http, config).into()
     }
 }

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -34,7 +34,7 @@ impl HttpsConnector<HttpConnector> {
         http.enforce_http(false);
         let mut config = ClientConfig::new();
         config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-        #[cfg(feature = "rustls-native-certs")] 
+        #[cfg(feature = "rustls-native-certs")]
         {
             config.root_store = match rustls_native_certs::load_native_certs() {
                 Ok(store) => store,
@@ -47,7 +47,7 @@ impl HttpsConnector<HttpConnector> {
                 }
             };
         }
-        #[cfg(feature = "webpki-roots")] 
+        #[cfg(feature = "webpki-roots")]
         {
             config
                 .root_store
@@ -73,7 +73,7 @@ impl<T> fmt::Debug for HttpsConnector<T> {
 
 impl<H, C> From<(H, C)> for HttpsConnector<H>
 where
-    C: Into<Arc<ClientConfig>> 
+    C: Into<Arc<ClientConfig>>
 {
     fn from((http, cfg): (H, C)) -> Self {
         HttpsConnector {


### PR DESCRIPTION
It looks like hyper-rustls wants to abstract over the differences between using the webpki-roots and rustls-native-certs backend, but this just bit me in an unobvious way that I think could be improved. I'm building a scratch container, meaning it only contains the statically linked binary and nothing else. One of my dependencies uses hyper-rustls as a dependency with the default features. As a result, (a) rustls-native-certs returns an empty `RootCertStore` without flagging that there might be an issue, (b) when hyper tries to connect through the `Connector`, it fails with a `webpki::Error::UnknownIssuer`. And, this doesn't happen when testing outside the containerized environment, but fails inside the container.

I feel like something should probably generate an error or panic if this happens, but I'm not sure which level of the stack is most appropriate. Since the return value of `rustls_native_certs::load_native_certs()` is technically correct, I feel like the problem here is in how hyper-rustls tries to abstract over the differences.

The solution implemented here is to have hyper-rustls panic if `Connector::new()` doesn't find any trust anchors; since it can already panic when it is unable to access a native cert store, this seems like an okay solution. Alternatively, maybe `rustls_native_certs::load_native_certs()` should return an error if it doesn't find anything? This is technically correct but not very useful behavior.