### PR TITLE
Force backend choice through API rather than features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,13 @@ tokio-runtime =  ["hyper/full", "ct-logs"]
 [[example]]
 name = "client"
 path = "examples/client.rs"
-required-features = ["tokio-runtime"]
+required-features = ["native-tokio", "tokio-runtime"]
 
 [[example]]
 name = "server"
 path = "examples/server.rs"
 required-features = ["tokio-runtime"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -55,7 +55,7 @@ async fn run_client() -> io::Result<()> {
             hyper_rustls::HttpsConnector::from((http, tls))
         }
         // Default HTTPS connector.
-        None => hyper_rustls::HttpsConnector::new(),
+        None => hyper_rustls::HttpsConnector::with_native_roots(),
     };
 
     // Build the hyper client from the HTTPS connector.

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -6,10 +6,7 @@
 //! otherwise HTTP/1.1 will be used.
 use async_stream::stream;
 use core::task::{Context, Poll};
-use futures_util::{
-    future::TryFutureExt,
-    stream::Stream,
-};
+use futures_util::{future::TryFutureExt, stream::Stream};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use rustls::internal::pemfile;

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -2,6 +2,7 @@ use futures_util::FutureExt;
 #[cfg(feature = "tokio-runtime")]
 use hyper::client::connect::HttpConnector;
 use hyper::{client::connect::Connection, service::Service, Uri};
+use log::warn;
 use rustls::ClientConfig;
 use std::future::Future;
 use std::pin::Pin;
@@ -11,7 +12,6 @@ use std::{fmt, io};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_rustls::TlsConnector;
 use webpki::DNSNameRef;
-use log::warn;
 
 use crate::stream::MaybeHttpsStream;
 
@@ -24,7 +24,10 @@ pub struct HttpsConnector<T> {
     tls_config: Arc<ClientConfig>,
 }
 
-#[cfg(all(any(feature = "rustls-native-certs", feature = "webpki-roots"), feature = "tokio-runtime"))]
+#[cfg(all(
+    any(feature = "rustls-native-certs", feature = "webpki-roots"),
+    feature = "tokio-runtime"
+))]
 impl HttpsConnector<HttpConnector> {
     /// Construct a new `HttpsConnector`.
     ///
@@ -42,9 +45,7 @@ impl HttpsConnector<HttpConnector> {
                     warn!("Could not load all certificates: {:?}", err);
                     store
                 }
-                Err((None, err)) => {
-                    Err(err).expect("cannot access native cert store")
-                }
+                Err((None, err)) => Err(err).expect("cannot access native cert store"),
             };
         }
         #[cfg(feature = "webpki-roots")]
@@ -61,7 +62,10 @@ impl HttpsConnector<HttpConnector> {
     }
 }
 
-#[cfg(all(any(feature = "rustls-native-certs", feature = "webpki-roots"), feature = "tokio-runtime"))]
+#[cfg(all(
+    any(feature = "rustls-native-certs", feature = "webpki-roots"),
+    feature = "tokio-runtime"
+))]
 impl Default for HttpsConnector<HttpConnector> {
     fn default() -> Self {
         Self::new()
@@ -76,7 +80,7 @@ impl<T> fmt::Debug for HttpsConnector<T> {
 
 impl<H, C> From<(H, C)> for HttpsConnector<H>
 where
-    C: Into<Arc<ClientConfig>>
+    C: Into<Arc<ClientConfig>>,
 {
     fn from((http, cfg): (H, C)) -> Self {
         HttpsConnector {

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -29,46 +29,43 @@ pub struct HttpsConnector<T> {
     feature = "tokio-runtime"
 ))]
 impl HttpsConnector<HttpConnector> {
-    /// Construct a new `HttpsConnector`.
-    ///
-    /// Takes number of DNS worker threads.
-    pub fn new() -> Self {
-        let mut http = HttpConnector::new();
-        http.enforce_http(false);
+    /// Construct a new `HttpsConnector` using the OS root store
+    #[cfg(feature = "rustls-native-certs")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-native-certs")))]
+    pub fn with_native_roots() -> Self {
         let mut config = ClientConfig::new();
-        config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-        #[cfg(feature = "rustls-native-certs")]
-        {
-            config.root_store = match rustls_native_certs::load_native_certs() {
-                Ok(store) => store,
-                Err((Some(store), err)) => {
-                    warn!("Could not load all certificates: {:?}", err);
-                    store
-                }
-                Err((None, err)) => Err(err).expect("cannot access native cert store"),
-            };
-        }
-        #[cfg(feature = "webpki-roots")]
-        {
-            config
-                .root_store
-                .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-        }
-        config.ct_logs = Some(&ct_logs::LOGS);
+        config.root_store = match rustls_native_certs::load_native_certs() {
+            Ok(store) => store,
+            Err((Some(store), err)) => {
+                warn!("Could not load all certificates: {:?}", err);
+                store
+            }
+            Err((None, err)) => Err(err).expect("cannot access native cert store"),
+        };
         if config.root_store.is_empty() {
             panic!("no CA certificates found");
         }
-        (http, config).into()
+        Self::build(config)
     }
-}
 
-#[cfg(all(
-    any(feature = "rustls-native-certs", feature = "webpki-roots"),
-    feature = "tokio-runtime"
-))]
-impl Default for HttpsConnector<HttpConnector> {
-    fn default() -> Self {
-        Self::new()
+    /// Construct a new `HttpsConnector` using the `webpki_roots`
+    #[cfg(feature = "webpki-roots")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "webpki-roots")))]
+    pub fn with_webpki_roots() -> Self {
+        let mut config = ClientConfig::new();
+        config
+            .root_store
+            .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+        Self::build(config)
+    }
+
+    fn build(mut config: ClientConfig) -> Self {
+        let mut http = HttpConnector::new();
+        http.enforce_http(false);
+
+        config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+        config.ct_logs = Some(&ct_logs::LOGS);
+        (http, config).into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,13 @@
 //! ## Example
 //!
 //! ```no_run
-//! # #[cfg(all(any(feature = "rustls-native-certs", feature = "webpki-roots"), feature = "tokio-runtime"))]
+//! # #[cfg(all(feature = "rustls-native-certs", feature = "tokio-runtime"))]
 //! # fn main() {
 //! use hyper::{Body, Client, StatusCode, Uri};
 //!
 //! let mut rt = tokio::runtime::Runtime::new().unwrap();
 //! let url = ("https://hyper.rs").parse().unwrap();
-//! let https = hyper_rustls::HttpsConnector::new();
+//! let https = hyper_rustls::HttpsConnector::with_native_roots();
 //!
 //! let client: Client<_, hyper::Body> = Client::builder().build(https);
 //!
@@ -21,15 +21,6 @@
 //! # #[cfg(not(feature = "tokio-runtime"))]
 //! # fn main() {}
 //! ```
-
-#[cfg(all(
-    feature = "tokio-runtime",
-    any(not(feature = "rustls-native-certs"), feature = "webpki-roots"),
-    any(not(feature = "webpki-roots"), feature = "rustls-native-certs")
-))]
-compile_error!(
-    "Must enable exactly one of rustls-native-certs (default) or webpki-roots with tokio-runtime! (note: use `default-features = false' in a binary crate for one or other)"
-);
 
 mod connector;
 mod stream;


### PR DESCRIPTION
Unlike the suggestion in #125, this only enables the native-tokio feature by default, but it enables all features in docs.rs, annotating both of the `HttpsConnector` constructors with the required feature flags (the required feature is only available in nightly for now, but docs.rs always runs nightly rustdoc). I believe this is better since it doesn't unnecessarily bloat the dependency graph of downstream crates, but I'm happy to change it if you feel strongly about enabling both.