### PR TITLE
Upgrade to tokio 1.0 - hyper 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,24 @@ repository = "https://github.com/ctz/hyper-rustls"
 log = "0.4.4"
 ct-logs = { version = "^0.8", optional = true }
 futures-util = "0.3.1"
-hyper = { git = "https://github.com/hyperium/hyper.git", default-features = false, features = ["full"] }
+hyper = { version = "0.14", default-features = false, features = ["client", "http1"] }
 rustls = "0.19"
 rustls-native-certs = { version = "0.5.0", optional = true }
-tokio = "0.3.4"
-tokio-rustls = "0.21.0"
+tokio = "1.0"
+tokio-rustls = "0.22"
 webpki = "0.21.0"
 webpki-roots = { version = "0.21", optional = true }
 
 [dev-dependencies]
 async-stream = "0.3.0"
-tokio = { version = "0.3", features = ["io-std", "macros", "net", "stream", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
+hyper = { version = "0.14", features = ["full"] }
 
 [features]
 default = ["native-tokio"]
 webpki-tokio = ["tokio-runtime", "webpki-roots"]
 native-tokio = ["tokio-runtime", "rustls-native-certs"]
-tokio-runtime =  ["hyper/full", "ct-logs"]
+tokio-runtime =  ["hyper/runtime", "ct-logs"]
 
 [[example]]
 name = "client"


### PR DESCRIPTION
Also tries to reduce the features enabled for `hyper`

~~EDIT: I forgot to make this into a draft PR. Anyway, let's wait for tokio-rustls to be released, at the moment we are importing it from git.~~