### PR TITLE
Remove futures-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/ctz/hyper-rustls"
 [dependencies]
 log = "0.4.4"
 ct-logs = { version = "^0.8", optional = true }
-futures-util = "0.3.1"
 hyper = { version = "0.14", default-features = false, features = ["client", "http1"] }
 rustls = "0.19"
 rustls-native-certs = { version = "0.5.0", optional = true }
@@ -25,6 +24,7 @@ webpki-roots = { version = "0.21", optional = true }
 async-stream = "0.3.0"
 tokio = { version = "1.0", features = ["io-std", "macros", "net", "rt-multi-thread"] }
 hyper = { version = "0.14", features = ["full"] }
+futures-util = { version = "0.3.1", default-features = false }
 
 [features]
 default = ["native-tokio"]

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -1,4 +1,3 @@
-use futures_util::FutureExt;
 #[cfg(feature = "tokio-runtime")]
 use hyper::client::connect::HttpConnector;
 use hyper::{client::connect::Connection, service::Service, Uri};
@@ -119,7 +118,7 @@ where
 
                 Ok(MaybeHttpsStream::Http(tcp))
             };
-            f.boxed()
+            Box::pin(f)
         } else {
             let cfg = self.tls_config.clone();
             let hostname = dst.host().unwrap_or_default().to_string();
@@ -136,7 +135,7 @@ where
                     .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
                 Ok(MaybeHttpsStream::Https(tls))
             };
-            f.boxed()
+            Box::pin(f)
         }
     }
 }


### PR DESCRIPTION
`h2`, `hyper` and `reqwest` import `futures-util` with no default features, to make it faster to compile. This crate doesn't actually need it, so I moved it to dev-dependencies where an example uses it.